### PR TITLE
Feature/engine more stable build

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -9,7 +9,6 @@ FILESEXTRAPATHS_prepend_poky := "${THISDIR}/files:"
 ENGINE_URI ?= "git@github.com:flutter/engine.git"
 SRC_URI = "file://sysroot_gni.patch \
            file://custom_BUILD_gn.patch \
-           file://icu.patch \
            "
 
 S = "${WORKDIR}/git/src"
@@ -107,9 +106,6 @@ do_patch() {
     gclient.py sync ${GCLIENT_SYNC_OPT} ${PARALLEL_MAKE} -v
     git apply ../../sysroot_gni.patch
     git apply ../../custom_BUILD_gn.patch
-
-    cd third_party/icu
-    git apply ../../../../icu.patch
 }
 do_patch[depends] =+ " \
     depot-tools-native:do_populate_sysroot \

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -15,7 +15,7 @@ S = "${WORKDIR}/git/src"
 
 inherit python3native
 
-DEPENDS =+ " ninja-native depot-tools-native freetype"
+DEPENDS =+ " ninja-native depot-tools-native freetype flutter-sdk-native tar-native xz-native"
 
 require gn-utils.inc
 
@@ -109,6 +109,9 @@ do_patch() {
 }
 do_patch[depends] =+ " \
     depot-tools-native:do_populate_sysroot \
+    flutter-sdk-native:do_populate_sysroot \
+    tar-native:do_populate_sysroot \
+    xz-native:do_populate_sysroot \
     "
 
 ARGS_GN_FILE = "${S}/${@get_out_dir(d)}/args.gn"

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -3,8 +3,6 @@ DESCRIPTION = "Flutter Engine"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://flutter/LICENSE;md5=a60894397335535eb10b54e2fff9f265"
 
-SRCREV = "9e5072f0ce81206b99db3598da687a19ce57a863"
-
 FILESEXTRAPATHS_prepend_poky := "${THISDIR}/files:"
 ENGINE_URI ?= "git@github.com:flutter/engine.git"
 SRC_URI = "file://sysroot_gni.patch \
@@ -67,7 +65,8 @@ GN_ARGS = " \
   --target-toolchain ${S}/buildtools/linux-x64/clang \
   "
 
-GCLIENT_SYNC_OPT ?= "--nohooks --no-history --revision ${SRCREV}"
+# don't use --nohooks because it causes a compile error
+GCLIENT_SYNC_OPT ?= "--no-history"
 
 do_patch() {
 
@@ -76,12 +75,18 @@ do_patch() {
     export SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
     export SSH_AGENT_PID=${SSH_AGENT_PID}
 
+    ENGINE_REV=$(cat ${STAGING_DATADIR_NATIVE}/flutter/sdk/bin/internal/engine.version)
+
     cd ${S}/..
+
     gclient.py config --spec 'solutions = [
         {
             "managed" : False,
             "name" : "src/flutter",
             "url" : "'${ENGINE_URI}'",
+            "revision": "'${ENGINE_REV}'",
+            "deps_file": "DEPS",
+            "safesync_url": "",
             "custom_vars" : {
                 "download_android_deps" : False,
                 "download_windows_deps" : False,
@@ -124,7 +129,7 @@ ARGS_GN_APPEND = " \
 FLUTTER_TRIPLE = "${@gn_clang_triple_prefix(d)}"
 
 TARGET_GCC_VERSION ?= "9.2.0"
-TARGET_CLANG_VERSION ?= "11.0.0"
+TARGET_CLANG_VERSION ?= "13.0.0"
 do_configure() {
 
     bbnote "./flutter/tools/gn ${GN_ARGS}"


### PR DESCRIPTION
--nohooks option should not  be used because files generated by hook are used while compilation.
And, revision specifying should be done in `gclient config` because the resulting of dependencies solving is different between it and one of `gclient sync`.