### PR TITLE
flutter-engine: add gclient specific tasks to improve flutter-engine …

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine-native_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine-native_git.bb
@@ -11,42 +11,16 @@ S = "${WORKDIR}/git/src"
 
 inherit python3native native
 
-DEPENDS =+ " flutter-engine ninja-native depot-tools-native"
-
 require gn-utils.inc
+require flutter-engine.inc
+
+DEPENDS =+ " flutter-engine"
 
 COMPATIBLE_MACHINE = "(-)"
 COMPATIBLE_MACHINE_x86 = "(.*)"
 COMPATIBLE_MACHINE_x86-64 = "(.*)"
 
 GN_ARGS = ""
-
-do_patch() {
-
-    export CURL_CA_BUNDLE=${STAGING_BINDIR_NATIVE}/depot_tools/ca-certificates.crt
-    export PATH=${STAGING_BINDIR_NATIVE}/depot_tools:${PATH}
-    export SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
-    export SSH_AGENT_PID=${SSH_AGENT_PID}
-
-    cd ${S}/..
-    gclient.py config --spec 'solutions = [
-        {
-            "managed" : False,
-            "name" : "src/flutter",
-            "url" : "'${ENGINE_URI}'",
-            "custom_vars" : {
-                "download_android_deps" : False,
-                "download_windows_deps" : False,
-            }
-        }
-    ]'
-
-    cd ${S}
-    gclient.py sync --no-history --revision ${SRCREV} ${PARALLEL_MAKE} -v
-}
-do_patch[depends] =+ " \
-    depot-tools-native:do_populate_sysroot \
-    "
 
 do_configure() {
 

--- a/recipes-graphics/flutter-engine/flutter-engine.inc
+++ b/recipes-graphics/flutter-engine/flutter-engine.inc
@@ -1,0 +1,58 @@
+GCLIENT_SYNC_OPT = "--force --reset -D --no-history "
+GCLIENT_RUNHOOKS_OPT = ""
+
+DEPENDS =+ " ninja-native depot-tools-native flutter-sdk-native tar-native xz-native"
+
+addtask gclient_fetch    before do_patch after do_unpack
+addtask gclient_runhooks before do_configure after do_patch
+
+do_gclient_fetch() {
+    export http_proxy=${http_proxy}
+    export https_proxy=${https_proxy}
+    export HTTP_PROXY=${HTTP_PROXY}
+    export HTTPS_PROXY=${HTTPS_PROXY}
+    export CURL_CA_BUNDLE=${STAGING_BINDIR_NATIVE}/depot_tools/ca-certificates.crt
+    export PATH=${STAGING_BINDIR_NATIVE}/depot_tools:${PATH}
+    export SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
+    export SSH_AGENT_PID=${SSH_AGENT_PID}
+
+    ENGINE_REV=$(cat ${STAGING_DATADIR_NATIVE}/flutter/sdk/bin/internal/engine.version)
+
+    cd ${S}/..
+
+    gclient.py config --spec 'solutions = [
+        {
+            "managed" : False,
+            "name" : "src/flutter",
+            "url" : "'${ENGINE_URI}'",
+            "custom_vars" : {
+                "download_android_deps" : False,
+                "download_windows_deps" : False,
+            }
+        }
+    ]'
+
+    rm -rf ${S}/*
+
+    gclient.py sync --nohooks --noprehooks ${GCLIENT_SYNC_OPT} --revision ${ENGINE_REV} ${PARALLEL_MAKE} -v
+}
+
+do_gclient_fetch[depends] =+ " \
+    depot-tools-native:do_populate_sysroot \
+    flutter-sdk-native:do_populate_sysroot \
+    tar-native:do_populate_sysroot \
+    xz-native:do_populate_sysroot \
+    "
+
+do_gclient_runhooks() {
+    export http_proxy=${http_proxy}
+    export https_proxy=${https_proxy}
+    export HTTP_PROXY=${HTTP_PROXY}
+    export HTTPS_PROXY=${HTTPS_PROXY}
+    export PATH=${STAGING_BINDIR_NATIVE}/depot_tools:${PATH}
+
+    cd ${S}
+    gclient.py runhooks ${GCLIENT_RUNHOOKS_OPT} ${PARALLEL_MAKE}  -v
+}
+
+# vim:set ts=4 sw=4 sts=4 expandtab:


### PR DESCRIPTION
…build

In the previous version of flutter-engine's recipe,
gclient config and sync are executed in do_patch.
This is out of the normal yocto style.
So, the specific tasks about gclient, do_gclient_fetch and
do_gclient_runhooks are added.

do_gclient_fetch is the task to fetch source codes with `gclient config`
and `gclient sync`.
In this task, hooks of gclient should not be executed because
dependencies of flutter-engine are downloaded in hooks so that
it is not possible to control dependencies by patching after running
hooks.
Therefore, do_gclient_runhooks is created.
This task is to run hooks of gclient.
do_patch is executed between do_gclient_fetch and do_gclient_runhooks.

This changing does not solve all of flutter-engine build issues, but
make this recipe better as Yocto.

Signed-off-by: Kazuyoshi Akiyama <akiyama@nds-osk.co.jp>
Signed-off-by: Ayato Horie <horie@nds-osk.co.jp>